### PR TITLE
Disable SSL for PostgreSQL connections for local development

### DIFF
--- a/api/src/config/index.ts
+++ b/api/src/config/index.ts
@@ -60,6 +60,9 @@ const dbURI: string =
   (process.env.VCAP_SERVICES && JSON.parse(process.env.VCAP_SERVICES)["aws-rds"][0].credentials.uri) ||
   'postgres://docker_pg_user:docker_pg_pw@docker_db:5432/docker_db';
 
+// Disable SSL connections to PostgreSQL for local development.
+const dbDisableSSL:boolean = process.env.POSTGRES_DISABLE_SSL === 'true'
+
 const openIdConfig: OpenIDConfiguration = {
   issuerDiscover: process.env.ISSUER_DISCOVER || 'https://idp.int.identitysandbox.gov/.well-known/openid-configuration',
   clientId: process.env.CLIENT_ID || 'urn:gov:gsa:openidconnect.profiles:sp:sso:opm_usds:smeqa_staging',
@@ -73,6 +76,7 @@ const headerTokens: { [tokenName: string]: string } = headerTokenString;
 
 export { env };
 export { dbURI };
+export { dbDisableSSL };
 export { openIdConfig };
 export { sessionConfig };
 export { headerTokens };

--- a/api/src/database/index.ts
+++ b/api/src/database/index.ts
@@ -1,5 +1,5 @@
 import Sequelize, { QueryOptionsWithType, QueryTypes, Transaction } from 'sequelize';
-import { dbURI, env } from '../config';
+import { dbURI, env, dbDisableSSL } from '../config';
 import { logger } from '../utils/logger';
 import { initModels } from '../models/init-models';
 
@@ -43,11 +43,7 @@ export default class DB implements DBInterface {
       dialect: "postgres",
       // https://node-postgres.com/features/ssl
       // https://sequelize.org/docs/v6/other-topics/dialect-specific-things/
-      dialectOptions: {
-        ssl:{
-          rejectUnauthorized: false,
-        }
-      }
+      dialectOptions: dbDisableSSL ? { ssl: false } : { ssl: { rejectUnauthorized: false } }
     });
     try {
       initModels(this.sequelize);

--- a/api/src/database/sessionDb.ts
+++ b/api/src/database/sessionDb.ts
@@ -1,5 +1,5 @@
 import { Pool } from 'pg';
-import { dbURI, env } from '../config';
+import { dbURI, env, dbDisableSSL } from '../config';
 
 // We had to change this out for the conn string in postgres 15+
 // https://node-postgres.com/features/ssl
@@ -10,10 +10,7 @@ import { dbURI, env } from '../config';
     max:20,
     idleTimeoutMillis:60000,
     connectionTimeoutMillis: 2000,
-    ssl:{
-      rejectUnauthorized: false
-    }
-  
+    ssl: dbDisableSSL ? false : { rejectUnauthorized: false }
 });
 };
 export default CreatePool;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,13 @@ version: "3.7"
 
 services:
   api:
+    container_name: api
     build:
       context: api
       dockerfile: Dockerfile.compose
     environment:
       - POSTGRES_URI=postgres://docker_pg_user:docker_pg_pw@db:5432/docker_db
+      - POSTGRES_DISABLE_SSL=true
       - NODE_ENV=docker
       - PORT=9000
       - APP_ENV=docker
@@ -43,6 +45,7 @@ services:
     depends_on:
       - api
   db:
+    container_name: db
     image: postgres
     environment:
       - POSTGRES_DB=docker_db


### PR DESCRIPTION
This is necessary for local development using Docker. I left the production PostgreSQL SSL config as it was.

Additionally, renamed the api and db containers, the former also required for local development.