### PR TITLE
Update api to Node 18.20.4

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -85,6 +85,6 @@
     "winston-daily-rotate-file": "^4.5.0"
   },
   "engines": {
-    "node": "18.20.5"
+    "node": "18.20.4"
   }
 }


### PR DESCRIPTION
Previously, recently updated version does not exist in the buildpack. Buildpack message is as follows:

> A newer version of node is available in this buildpack. Please adjust your app to use version 18.20.4 instead of version 18.20.3 as soon as possible.