### PR TITLE
Bump Node to 18.20.6

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -85,6 +85,6 @@
     "winston-daily-rotate-file": "^4.5.0"
   },
   "engines": {
-    "node": "18.20.4"
+    "node": "18.20.6"
   }
 }


### PR DESCRIPTION
Support for 18.20.4 has been removed.